### PR TITLE
Added getRequiredCollateralAfterDeposit() to RPLVault

### DIFF
--- a/contracts/Tokens/RPLVault.sol
+++ b/contracts/Tokens/RPLVault.sol
@@ -159,6 +159,21 @@ contract RPLVault is UpgradeableBase, ERC4626Upgradeable {
     }
 
     /**
+     * @notice Calculates the required collateral after a specified deposit.
+     * @dev This function calculates the required collateral to ensure the contract remains sufficiently collateralized
+     * after a specified deposit amount. It compares the current balance with the required collateral based on
+     * the total assets, including the deposit.
+     * @param deposit The amount of the deposit to consider in the collateral calculation.
+     * @return The amount of collateral required after the specified deposit.
+     */
+    function getRequiredCollateralAfterDeposit(uint256 deposit) public view returns (uint256) {
+        uint256 currentBalance = IERC20(asset()).balanceOf(address(this));
+        uint256 fullBalance = totalAssets() + deposit;
+        uint256 requiredBalance = liquidityReserveRatio.mulDiv(fullBalance, 1e5, Math.Rounding.Up);
+        return requiredBalance > currentBalance ? requiredBalance : 0;
+    }
+
+    /**
      * @notice Calculates the required collateral to ensure the contract remains sufficiently collateralized.
      * @dev This function compares the current balance of assets in the contract with the desired collateralization ratio.
      * If the required collateral based on the desired ratio is greater than the current balance, the function returns
@@ -167,12 +182,7 @@ contract RPLVault is UpgradeableBase, ERC4626Upgradeable {
      * @return The amount of asset required to maintain the desired collateralization ratio, or 0 if no additional collateral is needed.
      */
     function getRequiredCollateral() public view returns (uint256) {
-        uint256 currentBalance = IERC20(asset()).balanceOf(address(this));
-        uint256 fullBalance = totalAssets();
-
-        uint256 requiredBalance = liquidityReserveRatio.mulDiv(fullBalance, 1e5, Math.Rounding.Up);
-
-        return requiredBalance > currentBalance ? requiredBalance : 0;
+        return getRequiredCollateralAfterDeposit(0);
     }
 
     /**ADMIN FUNCTIONS */


### PR DESCRIPTION
This adds the `getRequiredCollateralAfterDeposit` function, which is present in `WETHVault`, to `RPLVault`. It's a useful view when calculating how much RPL to deposit at once to ensure X minipools can be created.