### PR TITLE
Add getNextMinipoolAddress() to SNA

### DIFF
--- a/contracts/Operator/SuperNodeAccount.sol
+++ b/contracts/Operator/SuperNodeAccount.sol
@@ -595,7 +595,7 @@ contract SuperNodeAccount is UpgradeableBase, Errors {
         if (minipools.length == 0) {
             return address(0);
         }
-        return minipools[currentMinipool+1 % minipools.length];
+        return minipools[(currentMinipool+1) % minipools.length];
     }
 
     /**


### PR DESCRIPTION
Adds a view to SNA that retrieves the address of the next minipool to tick without modifying state.