### PR TITLE
Fixed fastDeployProtocol() in the sandbox script

### DIFF
--- a/scripts/utils/setup_sandbox.ts
+++ b/scripts/utils/setup_sandbox.ts
@@ -38,6 +38,8 @@ export const setupSandbox = async () => {
     admin,
     deployer,
     admin,
+    deployer,
+    admin,
     rocketStorage.address,
     wETH.address,
     sanctions.address,


### PR DESCRIPTION
One of the recent updates broke the sandbox deploy script, this fixes it.