### PR TITLE
Fix the initialize args for Treasurer

### DIFF
--- a/scripts/utils/deployment.ts
+++ b/scripts/utils/deployment.ts
@@ -118,7 +118,7 @@ export async function fastDeployProtocol(treasurer: SignerWithAddress, deployer:
     })
 
     const treasuryProxy = await retryOperation(async function () {
-        const at = await upgrades.deployProxy(await ethers.getContractFactory("Treasury", deployer), [directoryAddress], { 'initializer': 'initialize', 'kind': 'uups', 'unsafeAllow': ['constructor'] });
+        const at = await upgrades.deployProxy(await ethers.getContractFactory("Treasury", deployer), [treasurer.address], { 'initializer': 'initialize', 'kind': 'uups', 'unsafeAllow': ['constructor'] });
         if (log) console.log("admin treasury deployed to", at.address)
         return at
     })


### PR DESCRIPTION
This fixes the deploy script so `Treasurer` actually respects the `treasurer` argument instead of giving `TREASURER_ROLE` to the `Directory` contract.