### PR TITLE
Initialize oracle with block timestamp

### DIFF
--- a/contracts/Constellation/PoAConstellationOracle.sol
+++ b/contracts/Constellation/PoAConstellationOracle.sol
@@ -55,6 +55,7 @@ contract PoAConstellationOracle is IConstellationOracle, UpgradeableBase {
      */
     function initializeOracle(address _directoryAddress) public virtual initializer {
         super.initialize(_directoryAddress);
+        _lastUpdatedTotalYieldAccrued = block.timestamp;
     }
 
     /**


### PR DESCRIPTION
After 1.0.1, the WETHVault will require the oracle to have been updated recently to allow deposits. This PR initializes the oracle with the most recent update set to be the time of init, which prevents future deployments from requiring an initial oracle update to allow deposits.